### PR TITLE
chore: add helper function to eliminate HTTP response boilerplate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # MODE : local,  server
 MODE=
-# LB_STRATEGY: roundrobin, consistanthashing
+# LB_STRATEGY: roundrobin, consistenthashing
 LB_STRATEGY=
 # Experiment ID to store when running benchmark
 EXPERIMENT_ID=

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Grafana    (:7780 / :8000)  <-- dashboards
 | Strategy | Flag | Description |
 |---|---|---|
 | Round Robin | `roundrobin` | Cycles through backends sequentially |
-| Consistent Hashing | `consistanthashing` | FNV-32a hash of request URL maps to a backend on a consistent ring |
+| Consistent Hashing | `consistenthashing` | FNV-32a hash of request URL maps to a backend on a consistent ring |
 | Least Queue | `leastqueue` | Scrapes `vllm:num_requests_running` from each backend and routes to the least loaded (WIP) |
 | Least KV Cache | `least-kvcache` | TBA |
 
@@ -49,7 +49,7 @@ cp .env.example .env
 
 ```
 MODE=server           # or local
-LB_STRATEGY=roundrobin  # roundrobin | consistanthashing | leastqueue
+LB_STRATEGY=roundrobin  # roundrobin | consistenthashing | leastqueue
 ```
 
 ### Dev Mode (no GPU required)

--- a/docs/docs/getting-started/dev-mode.md
+++ b/docs/docs/getting-started/dev-mode.md
@@ -15,7 +15,7 @@ Instead of real vLLM instances, dev mode starts two simple HTTP servers that ret
 make local-up router=roundrobin
 ```
 
-Replace `roundrobin` with any valid strategy: `consistanthashing` | `leastqueue` | `least-kvcache`.
+Replace `roundrobin` with any valid strategy: `consistenthashing` | `leastqueue` | `least-kvcache`.
 
 ## Example request
 

--- a/docs/docs/getting-started/prerequisites.md
+++ b/docs/docs/getting-started/prerequisites.md
@@ -25,7 +25,7 @@ cp .env.example .env
 | Field | Description | Valid values |
 |---|---|---|
 | `MODE` | Which backend type to use | `server`, `local` |
-| `LB_STRATEGY` | Routing strategy for the load balancer | `roundrobin`, `consistanthashing`, `leastqueue` |
+| `LB_STRATEGY` | Routing strategy for the load balancer | `roundrobin`, `consistenthashing`, `leastqueue` |
 
 Example:
 

--- a/docs/docs/getting-started/production-mode.md
+++ b/docs/docs/getting-started/production-mode.md
@@ -51,7 +51,7 @@ If you downloaded the model to a different path, update both `backend-1` and `ba
 make server-up router=roundrobin
 ```
 
-Replace `roundrobin` with any valid strategy: `consistanthashing` or `leastqueue`.
+Replace `roundrobin` with any valid strategy: `consistenthashing` or `leastqueue`.
 
 ## Stopping the Stack
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -25,7 +25,7 @@ The router supports two modes, set via the `MODE` env variable:
 | Strategy | Flag | Description |
 |---|---|---|
 | Round Robin | `roundrobin` | Cycles through backends sequentially |
-| Consistent Hashing | `consistanthashing` | FNV-32a hash of request URL maps to a backend on a consistent ring |
+| Consistent Hashing | `consistenthashing` | FNV-32a hash of request URL maps to a backend on a consistent ring |
 | Least Queue | `leastqueue` | Scrapes `vllm:num_requests_running` from each backend and routes to the least loaded (WIP) |
 | Least KV Cache | `least-kvcache` | TBA |
 

--- a/docs/docs/reference/makefile-reference.md
+++ b/docs/docs/reference/makefile-reference.md
@@ -22,7 +22,7 @@ All common operations are wrapped in `make` targets. The `router=<strategy>` var
 The `router=` variable accepts:
 
 - `roundrobin`
-- `consistanthashing`
+- `consistenthashing`
 - `leastqueue`
 
 Example:

--- a/docs/docs/reference/routing-strategies.md
+++ b/docs/docs/reference/routing-strategies.md
@@ -21,7 +21,7 @@ Simple and stateless. Makes no assumptions about request cost or backend load. W
 
 ---
 
-### `consistanthashing`
+### `consistenthashing`
 
 Uses an FNV-32a hash of the request URL to deterministically map requests to a backend on a consistent hash ring.
 

--- a/router/loadbalancer/consistenthashing/consistenthashing.go
+++ b/router/loadbalancer/consistenthashing/consistenthashing.go
@@ -1,5 +1,5 @@
-// NOTE: will not be used in research analysis due to nature of bench simulation 
-package consistanthashing
+// NOTE: will not be used in research analysis due to nature of bench simulation
+package consistenthashing
 
 import (
 	"hash/fnv"
@@ -15,7 +15,7 @@ type CHashing struct {
 	Ring       map[uint32]*backend.Backend
 }
 
-func NewConsistantHash(backends []backend.Backend) *CHashing {
+func NewConsistentHash(backends []backend.Backend) *CHashing {
 	cHashInstance := CHashing{
 		Ring: make(map[uint32]*backend.Backend),
 	}

--- a/router/main.go
+++ b/router/main.go
@@ -100,7 +100,7 @@ func (lb *LBServer) backendHandler(w http.ResponseWriter, r *http.Request) {
 			log.Printf("error encoding response: %v", err)
 			return
 		}
-	// Local mode uses vllm servers as defined in docker-compose.yml
+	// Server mode uses vllm servers as defined in docker-compose.yml
 	case "server":
 		if r.Method != "POST" {
 			w.WriteHeader(http.StatusMethodNotAllowed)

--- a/router/main.go
+++ b/router/main.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"llm-routing-bench/router/backend"
 	"llm-routing-bench/router/loadbalancer"
-	"llm-routing-bench/router/loadbalancer/consistanthashing"
+	"llm-routing-bench/router/loadbalancer/consistenthashing"
 	"llm-routing-bench/router/loadbalancer/leastkvcache"
 	"llm-routing-bench/router/loadbalancer/leastqueue"
 	"llm-routing-bench/router/loadbalancer/random"
@@ -173,8 +173,8 @@ func main() {
 		rr = random.NewRandom(backends)
 	case "roundrobin":
 		rr = roundrobin.NewRoundRobin(backends)
-	case "consistanthashing":
-		rr = consistanthashing.NewConsistantHash(backends)
+	case "consistenthashing":
+		rr = consistenthashing.NewConsistentHash(backends)
 	case "leastqueue":
 		rr = leastqueue.NewLeastQueue(backends, 250*time.Millisecond)
 	case "leastkvcache":

--- a/router/main.go
+++ b/router/main.go
@@ -41,6 +41,22 @@ type ServerResponse struct {
 	Response string `json:"response"`
 }
 
+func writeJSONResponse(w http.ResponseWriter, response ServerResponse) {
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		log.Printf("error encoding response: %v", err)
+	}
+}
+
+// rejectMethod writes a 405 JSON error and returns true if r.Method != method.
+func rejectMethod(w http.ResponseWriter, r *http.Request, method string) bool {
+	if r.Method == method {
+		return false
+	}
+	w.WriteHeader(http.StatusMethodNotAllowed)
+	writeJSONResponse(w, ServerResponse{Message: "Request not supported", Status: "Error"})
+	return true
+}
+
 func (lb *LBServer) backendHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Select backend to send out request
@@ -61,19 +77,7 @@ func (lb *LBServer) backendHandler(w http.ResponseWriter, r *http.Request) {
 	switch mode {
 	// Local mode uses fake servers (HTTP servers) on local machine
 	case "local":
-		if r.Method != "GET" {
-			w.WriteHeader(http.StatusMethodNotAllowed)
-			response := ServerResponse{
-				Message:  "Request not supported",
-				Status:   "Error",
-				Response: "",
-			}
-
-			err := json.NewEncoder(w).Encode(response)
-			if err != nil {
-				log.Printf("error encoding response: %v", err)
-				return
-			}
+		if rejectMethod(w, r, "GET") {
 			return
 		}
 		resp, err := http.Get(selectedBackend.BackendURI)
@@ -89,32 +93,14 @@ func (lb *LBServer) backendHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		response := ServerResponse{
+		writeJSONResponse(w, ServerResponse{
 			Message:  "Selected Port Number: " + selectedBackend.BackendURI,
 			Status:   "OK",
 			Response: string(body),
-		}
-
-		err = json.NewEncoder(w).Encode(response)
-		if err != nil {
-			log.Printf("error encoding response: %v", err)
-			return
-		}
+		})
 	// Server mode uses vllm servers as defined in docker-compose.yml
 	case "server":
-		if r.Method != "POST" {
-			w.WriteHeader(http.StatusMethodNotAllowed)
-			response := ServerResponse{
-				Message:  "Request not supported",
-				Status:   "Error",
-				Response: "",
-			}
-
-			err := json.NewEncoder(w).Encode(response)
-			if err != nil {
-				log.Printf("error encoding response: %v", err)
-				return
-			}
+		if rejectMethod(w, r, "POST") {
 			return
 		}
 		bodyBytes, err := io.ReadAll(r.Body)
@@ -136,18 +122,11 @@ func (lb *LBServer) backendHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		response := ServerResponse{
+		writeJSONResponse(w, ServerResponse{
 			Message:  "Selected Port Number: " + selectedBackend.BackendURI,
 			Status:   "OK",
 			Response: string(body),
-		}
-
-		err = json.NewEncoder(w).Encode(response)
-		if err != nil {
-			log.Printf("error encoding response: %v", err)
-			return
-		}
-
+		})
 	}
 }
 


### PR DESCRIPTION
## Description
Extracted writeJSONResponse and rejectMethod helpers to eliminate duplicated HTTP response boilerplate in the router.

router/main.go— added two helpers, replaced inline response blocks with calls to them

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Other (describe):

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added tests (if applicable)
- [ ] New and existing tests pass locally
- [ ] I have updated documentation (if applicable)